### PR TITLE
fix: update asset resolution to include package name for Flutter assets

### DIFF
--- a/android/src/main/kotlin/com/avilatek/flutter_newpos_sdk/FlutterNewposSdkPlugin.kt
+++ b/android/src/main/kotlin/com/avilatek/flutter_newpos_sdk/FlutterNewposSdkPlugin.kt
@@ -27,6 +27,10 @@ import java.util.*
 
 /** FlutterNewposSdkPlugin */
 class FlutterNewposSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
+  companion object {
+    private const val FLUTTER_ASSET_PACKAGE = "flutter_newpos_sdk"
+  }
+
   /// The MethodChannel that will the communication between Flutter and native Android
   ///
   /// This local reference serves to register the plugin with the Flutter Engine and unregister it
@@ -303,7 +307,10 @@ class FlutterNewposSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     assetName: String
   ): Document {
     val applicationContext = flutterPluginBinding.applicationContext
-    val resolvedPath = flutterPluginBinding.flutterAssets.getAssetFilePathByName(assetName)
+    val resolvedPath = flutterPluginBinding.flutterAssets.getAssetFilePathByName(
+        assetName,
+        FLUTTER_ASSET_PACKAGE
+    )
 
     applicationContext.assets.open(resolvedPath).use { input ->
         val documentBuilderFactory = DocumentBuilderFactory.newInstance()


### PR DESCRIPTION
This pull request introduces a small but important update to the way Flutter assets are accessed in the Android plugin. The changes ensure that assets are loaded from the correct package by specifying the asset package name when resolving asset paths.

Asset loading improvements:

* Added a `companion object` to the `FlutterNewposSdkPlugin` class to define the constant `FLUTTER_ASSET_PACKAGE`, which holds the asset package name.
* Updated the asset loading logic to use `getAssetFilePathByName` with the asset package name, ensuring assets are resolved from the correct package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset resolution for the Flutter plugin to ensure bundled POS assets are correctly located during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->